### PR TITLE
feat: cache /api/narrative results in UI proxy

### DIFF
--- a/docs/plans/2026-02-18-feat-cache-narrative-results-ui-proxy-plan.md
+++ b/docs/plans/2026-02-18-feat-cache-narrative-results-ui-proxy-plan.md
@@ -1,0 +1,164 @@
+---
+title: "feat: Cache /api/narrative results in UI proxy"
+type: feature
+date: 2026-02-18
+detail_level: standard
+status: completed
+issue: https://github.com/Backland-Labs/agent-ui/issues/13
+---
+
+# feat: Cache /api/narrative results in UI proxy
+
+## Overview
+
+Add short-lived server-side caching to `GET /api/narrative` so repeated landing-page requests within a 60 second window can return normalized narrative data without re-calling the email-agent upstream endpoint, while preserving existing error behavior and response shape. Cache bypass via `refresh=1` is a behavior flag, not an authorization boundary.
+
+## Problem Statement / Motivation
+
+The landing UI calls `/api/narrative` on initial mount and on manual refresh. Today the proxy always performs upstream work, which increases latency and repeated load for quick reload/navigation patterns. We need a deterministic, testable cache that improves responsiveness while keeping user-facing behavior stable.
+
+## Detailed Background
+
+- Current route implementation (`src/app/api/narrative/route.ts`) always calls upstream `POST /narrative` after resolving `email-agent` endpoint configuration.
+- The route already normalizes payload shape and maps errors (`404` source unavailable, `502` upstream non-ok, `500` request failure), and emits structured logs for start/completion/failure.
+- Client refresh behavior lives in `src/lib/hooks/useNarrative.ts`; refresh currently calls the same URL as initial load and does not signal cache bypass intent.
+- Existing in-memory cache precedent in repo is `src/lib/server/google-calendar.ts`, using module-scoped cache with `60_000` ms TTL.
+- Existing narrative tests cover parsing/mapping/error cases but not cache semantics.
+
+## Stakeholders
+
+- End users loading the landing narrative card (faster repeated loads).
+- Engineers maintaining `src/app/api/narrative/route.ts` and `src/lib/hooks/useNarrative.ts`.
+- Observability owners who need cache hit/miss/bypass visibility in structured logs.
+
+## Acceptance Criteria
+
+- [ ] Repeated non-refresh requests within TTL return cached `200` data and do not call upstream again.
+- [ ] TTL boundary is deterministic: cache hit when `ageMs < 60000`; cache miss when `ageMs >= 60000`.
+- [ ] First non-refresh request after TTL expiry refetches upstream and rewrites cache on success.
+- [ ] Manual refresh uses explicit bypass signal (`refresh=1`) and forces upstream fetch even when cache is valid.
+- [ ] Bypass parsing is strict: only `refresh=1` bypasses cache; all other/missing values do not.
+- [ ] Refresh bypass rewrites cache only on successful `200` response; failed refresh does not overwrite existing cached success.
+- [ ] Cache write eligibility is explicit: write only after upstream `200` and successful normalization path; non-200/network failures are never cached.
+- [ ] Route keeps current single-attempt fetch behavior (no new timeout/retry policy changes in this issue).
+- [ ] Expired cache is not served; on expired-entry + upstream failure, route returns existing mapped error contract.
+- [ ] Existing response contract remains unchanged: `items`, `narrative`, `actionItems`; existing error mapping remains unchanged.
+- [ ] Cache key is endpoint-aware to avoid cross-endpoint contamination if endpoint identity changes.
+- [ ] Route emits structured cache observability events for `hit`, `miss`, and `bypass` with route-consistent event naming and fields: `requestId`, `cacheKey`, `cacheAgeMs` (when applicable), `bypass`, `source`, `upstreamStatus` (when applicable), and `durationMs`.
+- [ ] Tests cover hit/miss/expiry, refresh bypass, strict bypass parsing, non-caching of errors, endpoint-aware key isolation, and refresh signaling from the hook.
+
+## Proposed Solution
+
+1. Extend narrative route caching behavior in `src/app/api/narrative/route.ts`:
+   - Introduce module-scoped in-memory cache entry for successful normalized `LandingNarrativeResponse` payload.
+   - Use a 60 second TTL (`60_000` ms) matching existing repository cache style.
+   - Evaluate cache before upstream fetch for standard requests.
+   - Skip cache read when refresh bypass is requested.
+   - Cache only successful response payloads after normalization; do not cache failures.
+
+2. Add refresh-bypass request signal from hook in `src/lib/hooks/useNarrative.ts`:
+   - Keep initial load request as `/api/narrative`.
+   - Send refresh requests as `/api/narrative?refresh=1`.
+   - Preserve existing UI state behavior (overlay refresh error for non-404 refresh failures, terminal error on 404 refresh failures).
+
+3. Keep route wrapper thin and explicit:
+   - Update `GET` route export to accept `NextRequest`, parse `refresh` query, and pass bypass intent to `handleGetNarrative(...)` helper.
+   - Keep DB sync and error mapping behavior unchanged.
+
+4. Add cache observability logs in route:
+   - `narrative.cache_hit`
+   - `narrative.cache_miss`
+   - `narrative.cache_bypass`
+   - Include fields like `cacheAgeMs` (when applicable) and `durationMs` consistent with existing route logging style.
+
+5. Define cache correctness semantics up front:
+   - Keep expired cache entries non-servable; always attempt upstream after expiry.
+   - On expiry + upstream failure, return mapped error response and do not treat stale cache as fallback output in this issue.
+   - Use endpoint-aware cache keying based on resolved upstream endpoint identity.
+   - Keep refresh bypass parsing strict (`refresh=1` only).
+
+## Technical Considerations
+
+- Cache scope is process-local in-memory state; behavior is best-effort in multi-instance/serverless deployments.
+- Cache keying must include resolved endpoint identity to avoid cross-endpoint contamination.
+- Keep route and helper testability: preserve `handleGetNarrative(...)` as primary business-logic seam.
+- Add deterministic time control in tests (fake timers or injected `now` provider) to validate TTL boundaries without flakiness.
+- Prevent test cross-contamination from module-scoped cache by explicit cache reset strategy between tests.
+- Bypass parsing is strict: only `refresh=1` activates cache bypass.
+- Keep observability payloads low-cardinality and avoid logging narrative content/items.
+- Concurrency note: in-flight request deduplication is out of scope for this issue; plan focuses on TTL cache semantics and bypass correctness.
+
+## Research Note (Phase 3 Consolidation)
+
+- Key references and file paths:
+  - `src/app/api/narrative/route.ts`
+  - `src/lib/hooks/useNarrative.ts`
+  - `src/app/api/narrative/__tests__/route.test.ts`
+  - `src/lib/hooks/__tests__/useNarrative.test.ts`
+  - `src/lib/server/google-calendar.ts`
+  - `src/lib/server/__tests__/google-calendar.test.ts`
+  - `src/app/api/calendar/__tests__/route.test.ts`
+- Reusable learnings from `docs/solutions/`:
+  - `docs/solutions/integration-issues/pino-transport-bun-incompatibility-system-20260213.md` reinforces keeping logging runtime-safe and structured, with minimal request-path overhead.
+- External research decision:
+  - Skipped. Domain is low-risk and local code patterns are strong and directly reusable.
+- Open questions:
+  - None blocking for issue scope.
+
+## Dependencies and Risks
+
+- Dependency on configured `email-agent` endpoint in DB and upstream `/narrative` availability.
+- Risk of stale reads within TTL window; accepted tradeoff for reduced repeated upstream calls.
+- Risk of cache inconsistency across multiple server instances; mitigated by documenting process-local semantics.
+- Risk of brittle tests due to shared cache state; mitigated by explicit reset/time control.
+
+## Success Metrics
+
+- Narrative route tests verify one upstream call for repeated non-refresh requests within TTL.
+- Narrative route tests verify refetch occurs at/after expiry threshold and cache updates.
+- Narrative route tests verify strict bypass parsing and endpoint-aware cache-key isolation.
+- Hook tests verify refresh request uses bypass query parameter.
+- Existing response-shape and error-mapping tests remain green after cache changes.
+- Logging paths emit expected cache lifecycle events during hit/miss/bypass scenarios with required diagnostic fields and no payload content.
+
+## Implementation Plan
+
+- [x] Task 1: Add cache primitives and bypass-aware handler flow in `src/app/api/narrative/route.ts`.
+  - Add TTL constant and cache entry type for normalized narrative response.
+  - Add helper logic for reading valid cache, writing successful cache, and bypass checks.
+  - Keep `handleGetNarrative(...)` as route-logic seam with optional bypass/time injection for testing.
+
+- [x] Task 2: Wire route wrapper query parsing and hook refresh signaling.
+  - Update `GET` in `src/app/api/narrative/route.ts` to parse `refresh=1` and pass bypass flag.
+  - Update `fetchNarrative("refresh")` in `src/lib/hooks/useNarrative.ts` to call `/api/narrative?refresh=1`.
+
+- [x] Task 3: Expand route tests for cache behavior in `src/app/api/narrative/__tests__/route.test.ts`.
+  - Add tests for cache miss -> write -> hit.
+  - Add tests for deterministic expiry boundary (`ageMs < 60000` hit, `>= 60000` miss) and refetch.
+  - Add tests for bypass behavior (`refresh=1`) and strict parsing (non-`1` values do not bypass).
+  - Add tests for non-overwrite on bypass failure and expired-cache + upstream-failure behavior.
+  - Add tests ensuring errors are not cached, endpoint-aware key isolation, and existing error mapping remains unchanged.
+
+- [x] Task 4: Expand hook tests in `src/lib/hooks/__tests__/useNarrative.test.ts`.
+  - Assert initial mount uses `/api/narrative`.
+  - Assert manual refresh uses `/api/narrative?refresh=1`.
+  - Keep existing refresh state/error semantics covered.
+
+- [x] Task 5: Validation run.
+  - `bun run test src/app/api/narrative/__tests__/route.test.ts`
+  - `bun run test src/lib/hooks/__tests__/useNarrative.test.ts`
+  - `bun run typecheck`
+  - `bun run lint`
+  - Note: repo-wide `bun run lint` currently fails because generated files under `.worktrees/**/.next/**` are included; changed narrative files pass targeted `eslint`.
+
+## References
+
+- Issue: `https://github.com/Backland-Labs/agent-ui/issues/13`
+- Route implementation: `src/app/api/narrative/route.ts`
+- Hook implementation: `src/lib/hooks/useNarrative.ts`
+- Narrative route tests: `src/app/api/narrative/__tests__/route.test.ts`
+- Narrative hook tests: `src/lib/hooks/__tests__/useNarrative.test.ts`
+- Existing cache pattern: `src/lib/server/google-calendar.ts`
+- Existing cache tests: `src/lib/server/__tests__/google-calendar.test.ts`
+- Route wrapper test pattern: `src/app/api/calendar/__tests__/route.test.ts`
+- AGENTS guidance: `AGENTS.md`

--- a/src/app/api/digest/__tests__/route.get.test.ts
+++ b/src/app/api/digest/__tests__/route.get.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+type MockQueryResult = Array<Record<string, unknown>>;
+
+function createMockQuery(result: MockQueryResult) {
+  type MockQuery = {
+    from: () => MockQuery;
+    innerJoin: () => MockQuery;
+    where: () => MockQuery;
+    orderBy: () => MockQuery;
+    groupBy: () => MockQuery;
+    limit: () => Promise<MockQueryResult>;
+    then: (
+      resolve: (value: MockQueryResult) => unknown,
+      reject?: (reason: unknown) => unknown
+    ) => Promise<unknown>;
+  };
+
+  const chain: MockQuery = {
+    from: () => chain,
+    innerJoin: () => chain,
+    where: () => chain,
+    orderBy: () => chain,
+    groupBy: () => chain,
+    limit: () => Promise.resolve(result),
+    then: (resolve, reject) => Promise.resolve(result).then(resolve, reject),
+  };
+
+  return chain;
+}
+
+const mockDb = {
+  select: vi.fn(() => createMockQuery([])),
+  get selectCallCount() {
+    return this.select.mock.calls.length;
+  },
+};
+
+function setMockDb(queryResults: MockQueryResult[]) {
+  let cursor = 0;
+
+  mockDb.select = vi.fn(() => {
+    const queryResult = queryResults[cursor] ?? [];
+    cursor += 1;
+    return createMockQuery(queryResult);
+  }) as typeof mockDb.select;
+}
+
+vi.mock("../../../../../db/client", () => ({
+  db: mockDb,
+}));
+
+async function importRoute() {
+  vi.resetModules();
+  const route = await import("../route");
+  return route as typeof import("../route");
+}
+
+describe("GET /api/digest", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    setMockDb([]);
+  });
+
+  it("uses valid now param for window boundaries", async () => {
+    setMockDb([
+      [
+        {
+          id: "thread-1",
+          agent_id: "agent-1",
+          title: "Morning",
+          last_activity_at: new Date("2026-02-14T11:00:00.000Z"),
+          agent_name: "Agent One",
+        },
+      ],
+      [],
+      [{ value: 1 }],
+      [{ value: 0 }],
+      [{ value: 1 }],
+      [{ agent_id: "agent-1", agent_name: "Agent One", count: 1 }],
+      [{ agent_id: "agent-1", agent_name: "Agent One", count: 1 }],
+    ]);
+
+    const { GET } = await importRoute();
+    const request = new NextRequest("http://localhost/api/digest?now=2026-02-14T12:00:00.000Z");
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockDb.selectCallCount).toBe(7);
+    expect(body.generatedAt).toContain("2026-02-14T12:00:00");
+  });
+
+  it("falls back to current time for invalid now param", async () => {
+    const now = Date.now();
+
+    setMockDb([
+      [
+        {
+          id: "thread-1",
+          agent_id: "agent-1",
+          title: "Fallback",
+          last_activity_at: new Date("2026-02-14T11:00:00.000Z"),
+          agent_name: "Agent One",
+        },
+      ],
+      [],
+      [{ value: 1 }],
+      [{ value: 0 }],
+      [{ value: 1 }],
+      [{ agent_id: "agent-1", agent_name: "Agent One", count: 1 }],
+      [{ agent_id: "agent-1", agent_name: "Agent One", count: 1 }],
+    ]);
+
+    const { GET } = await importRoute();
+    const request = new NextRequest("http://localhost/api/digest?now=not-a-date");
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockDb.selectCallCount).toBe(7);
+    expect(typeof body.generatedAt).toBe("string");
+    expect(new Date(body.generatedAt).getTime()).toBeGreaterThanOrEqual(now - 5_000);
+  });
+});

--- a/src/app/api/digest/__tests__/route.test.ts
+++ b/src/app/api/digest/__tests__/route.test.ts
@@ -127,6 +127,75 @@ describe("GET /api/digest", () => {
     });
   });
 
+  it("truncates long snippets and preserves the latest thread text", async () => {
+    const agent = await seedAgent(db);
+    const thread = await seedThread(db, agent.id, {
+      title: "Long update",
+      last_activity_at: new Date("2026-02-14T11:05:00.000Z"),
+      created_at: new Date("2026-02-14T11:05:00.000Z"),
+    });
+    await seedMessage(db, thread.id, {
+      content: "x".repeat(140),
+      created_at: new Date("2026-02-14T11:20:00.000Z"),
+    });
+    await seedRun(db, thread.id);
+
+    const response = await handleGetDigest(db, new Date("2026-02-14T12:00:00.000Z"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.topItems).toHaveLength(1);
+    expect(data.topItems[0]).toMatchObject({
+      subject: "Long update",
+      snippet: `${"x".repeat(130)}…`,
+    });
+  });
+
+  it("normalizes unknown message role and null message to defaults", async () => {
+    const agent = await seedAgent(db);
+    const thread = await seedThread(db, agent.id, {
+      title: "No latest message",
+      last_activity_at: new Date("2026-02-14T10:00:00.000Z"),
+      created_at: new Date("2026-02-14T10:00:00.000Z"),
+    });
+
+    await seedMessage(db, thread.id, {
+      role: "human" as unknown as "user",
+      content: "Should be hidden",
+      created_at: new Date("2026-02-14T10:20:00.000Z"),
+    });
+
+    const response = await handleGetDigest(db, new Date("2026-02-14T12:00:00.000Z"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.topItems).toHaveLength(1);
+    expect(data.topItems[0]).toMatchObject({
+      subject: "No latest message",
+      lastMessageRole: null,
+    });
+  });
+
+  it("returns fallback snippet when no latest message exists", async () => {
+    const agent = await seedAgent(db);
+    await seedThread(db, agent.id, {
+      title: "No messages at all",
+      last_activity_at: new Date("2026-02-14T09:00:00.000Z"),
+      created_at: new Date("2026-02-14T09:00:00.000Z"),
+    });
+
+    const response = await handleGetDigest(db, new Date("2026-02-14T12:00:00.000Z"));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.topItems).toHaveLength(1);
+    expect(data.topItems[0]).toMatchObject({
+      subject: "No messages at all",
+      snippet: "No messages yet",
+      lastMessageRole: null,
+    });
+  });
+
   it("returns empty-but-valid payload when there is no recent activity", async () => {
     const response = await handleGetDigest(db, new Date("2026-02-14T12:00:00.000Z"));
     const data = await response.json();

--- a/src/app/api/narrative/__tests__/route.get.test.ts
+++ b/src/app/api/narrative/__tests__/route.get.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+type AgentRow = { endpoint_url: string; name?: string };
+
+type MockDb = {
+  select: ReturnType<typeof vi.fn>;
+};
+
+const mockDb: MockDb = {
+  select: vi.fn(),
+};
+const syncAgentsToDb = vi.fn();
+
+function createMockDb(agents: AgentRow[]): MockDb {
+  return {
+    select: vi.fn(() => ({
+      from: () => ({
+        where: () =>
+          Promise.resolve(
+            agents.map((agent) => ({
+              endpointUrl: agent.endpoint_url,
+              name: agent.name ?? "Email Agent",
+            }))
+          ),
+      }),
+    })),
+  };
+}
+
+function setMockDb(agents: AgentRow[]) {
+  mockDb.select = createMockDb(agents).select;
+}
+
+vi.mock("../../../../../db/client", () => ({
+  db: mockDb,
+}));
+
+vi.mock("../../../../../db/sync-agents", () => ({
+  syncAgentsToDb,
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function importRoute() {
+  syncAgentsToDb.mockReset().mockResolvedValue(undefined);
+  vi.resetModules();
+  return import("../route");
+}
+
+describe("GET /api/narrative", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    syncAgentsToDb.mockReset().mockResolvedValue(undefined);
+    setMockDb([]);
+  });
+
+  it("normalizes endpoint and refreshes cache on refresh=1", async () => {
+    setMockDb([{ endpoint_url: "https://agent.example/agent", name: "Email Agent" }]);
+
+    const route = await importRoute();
+    await route.resetNarrativeCacheForTests();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "first",
+              title: "First",
+              snippet: "first",
+              timestamp: 1_700_000_000_000,
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "second",
+              title: "Second",
+              snippet: "second",
+              timestamp: 1_700_000_100_000,
+            },
+          ],
+        })
+      );
+
+    const firstResponse = await route.GET(new NextRequest("http://localhost/api/narrative"));
+    const firstData = await firstResponse.json();
+    const secondResponse = await route.GET(
+      new NextRequest("http://localhost/api/narrative?refresh=1")
+    );
+    const secondData = await secondResponse.json();
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(syncAgentsToDb).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenNthCalledWith(1, "https://agent.example/narrative", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(firstData.items[0]).toMatchObject({ threadId: "first" });
+    expect(secondData.items[0]).toMatchObject({ threadId: "second" });
+  });
+
+  it("serves cached data when refresh flag is not set", async () => {
+    setMockDb([{ endpoint_url: "https://agent.example/agent" }]);
+    const route = await importRoute();
+
+    await route.resetNarrativeCacheForTests();
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          {
+            thread_id: "cached",
+            title: "Cached",
+            snippet: "cached",
+            timestamp: 1_700_000_000_000,
+          },
+        ],
+      })
+    );
+
+    const firstResponse = await route.GET(new NextRequest("http://localhost/api/narrative"));
+    const firstData = await firstResponse.json();
+    const secondResponse = await route.GET(new NextRequest("http://localhost/api/narrative"));
+    const secondData = await secondResponse.json();
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(syncAgentsToDb).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(firstData).toMatchObject(secondData);
+  });
+});

--- a/src/app/api/narrative/__tests__/route.test.ts
+++ b/src/app/api/narrative/__tests__/route.test.ts
@@ -3,7 +3,11 @@ import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import { migrate } from "drizzle-orm/libsql/migrator";
 import * as schema from "../../../../../db/schema";
-import { handleGetNarrative } from "../route";
+import {
+  handleGetNarrative,
+  resetNarrativeCacheForTests,
+  shouldBypassNarrativeCache,
+} from "../route";
 
 type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 
@@ -14,11 +18,11 @@ async function createTestDb(): Promise<TestDb> {
   return db;
 }
 
-async function seedEmailAgent(db: TestDb) {
+async function seedEmailAgent(db: TestDb, endpointUrl = "http://email-agent.test/agent") {
   await db.insert(schema.agents).values({
     id: "email-agent",
     name: "Email Agent",
-    endpoint_url: "http://email-agent.test/agent",
+    endpoint_url: endpointUrl,
     status: "online" as const,
     icon: "bot",
     description: "Email inbox agent",
@@ -39,6 +43,7 @@ describe("GET /api/narrative", () => {
 
   beforeEach(async () => {
     db = await createTestDb();
+    resetNarrativeCacheForTests();
   });
 
   it("normalizes, sorts, and limits narrative items", async () => {
@@ -280,5 +285,294 @@ describe("GET /api/narrative", () => {
     expect(data.items).toEqual([]);
     expect(data.narrative).toBe("");
     expect(data.actionItems).toEqual([]);
+  });
+
+  it("reuses cached successful response for repeated requests within TTL", async () => {
+    await seedEmailAgent(db);
+
+    const fetcher = vi.fn().mockResolvedValue(
+      jsonResponse({
+        items: [
+          {
+            thread_id: "thread-1",
+            title: "First",
+            snippet: "cached",
+            last_activity_at: "2026-02-16T12:01:00.000Z",
+          },
+        ],
+        narrative: "Cached narrative",
+        actionItems: ["Reply to thread-1"],
+      })
+    );
+
+    const firstResponse = await handleGetNarrative(db, fetcher, { nowMs: 1_000 });
+    const firstData = await firstResponse.json();
+    const secondResponse = await handleGetNarrative(db, fetcher, { nowMs: 1_500 });
+    const secondData = await secondResponse.json();
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(secondData).toEqual(firstData);
+  });
+
+  it("treats cache entry as expired when age reaches TTL boundary", async () => {
+    await seedEmailAgent(db);
+
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "thread-a",
+              title: "First",
+              snippet: "first",
+              last_activity_at: "2026-02-16T12:01:00.000Z",
+            },
+          ],
+          narrative: "Summary A",
+          actionItems: [],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "thread-b",
+              title: "Second",
+              snippet: "second",
+              last_activity_at: "2026-02-16T12:02:00.000Z",
+            },
+          ],
+          narrative: "Summary B",
+          actionItems: ["Reply to thread-b"],
+        })
+      );
+
+    await handleGetNarrative(db, fetcher, { nowMs: 10_000 });
+    const response = await handleGetNarrative(db, fetcher, { nowMs: 70_000 });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(data.items[0]).toMatchObject({ threadId: "thread-b" });
+    expect(data.narrative).toBe("Summary B");
+    expect(data.actionItems).toEqual(["Reply to thread-b"]);
+  });
+
+  it("bypasses cache and refreshes stored payload when requested", async () => {
+    await seedEmailAgent(db);
+
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "thread-old",
+              title: "Old",
+              snippet: "old",
+              last_activity_at: "2026-02-16T12:01:00.000Z",
+            },
+          ],
+          narrative: "Summary old",
+          actionItems: [],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "thread-new",
+              title: "New",
+              snippet: "new",
+              last_activity_at: "2026-02-16T12:02:00.000Z",
+            },
+          ],
+          narrative: "Summary new",
+          actionItems: ["Reply to thread-new"],
+        })
+      );
+
+    await handleGetNarrative(db, fetcher, { nowMs: 1_000 });
+
+    const bypassResponse = await handleGetNarrative(db, fetcher, {
+      bypassCache: true,
+      nowMs: 1_500,
+    });
+    const bypassData = await bypassResponse.json();
+
+    const cachedResponse = await handleGetNarrative(db, fetcher, { nowMs: 2_000 });
+    const cachedData = await cachedResponse.json();
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(bypassData.items[0]).toMatchObject({ threadId: "thread-new" });
+    expect(cachedData.items[0]).toMatchObject({ threadId: "thread-new" });
+  });
+
+  it("keeps prior cached success when bypass refresh fails", async () => {
+    await seedEmailAgent(db);
+
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "thread-cached",
+              title: "Cached",
+              snippet: "cached",
+              last_activity_at: "2026-02-16T12:01:00.000Z",
+            },
+          ],
+          narrative: "Cached summary",
+          actionItems: [],
+        })
+      )
+      .mockResolvedValueOnce(new Response("upstream failure", { status: 500 }));
+
+    await handleGetNarrative(db, fetcher, { nowMs: 1_000 });
+
+    const failedBypassResponse = await handleGetNarrative(db, fetcher, {
+      bypassCache: true,
+      nowMs: 1_500,
+    });
+    expect(failedBypassResponse.status).toBe(502);
+
+    const cachedResponse = await handleGetNarrative(db, fetcher, { nowMs: 2_000 });
+    const cachedData = await cachedResponse.json();
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(cachedResponse.status).toBe(200);
+    expect(cachedData.items[0]).toMatchObject({ threadId: "thread-cached" });
+  });
+
+  it("does not serve stale cache when expired entry refetch fails", async () => {
+    await seedEmailAgent(db);
+
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "thread-old",
+              title: "Old",
+              snippet: "old",
+              last_activity_at: "2026-02-16T12:01:00.000Z",
+            },
+          ],
+          narrative: "Summary old",
+          actionItems: [],
+        })
+      )
+      .mockResolvedValueOnce(new Response("upstream failure", { status: 500 }));
+
+    await handleGetNarrative(db, fetcher, { nowMs: 1_000 });
+
+    const response = await handleGetNarrative(db, fetcher, { nowMs: 61_000 });
+    const data = await response.json();
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(502);
+    expect(data).toMatchObject({ error: "Unable to load email narrative" });
+  });
+
+  it("does not cache non-ok upstream responses", async () => {
+    await seedEmailAgent(db);
+
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("bad", { status: 500 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "thread-2",
+              title: "Recovered",
+              snippet: "ok",
+              last_activity_at: "2026-02-16T12:02:00.000Z",
+            },
+          ],
+          narrative: "Recovered summary",
+          actionItems: ["Follow up"],
+        })
+      );
+
+    const firstResponse = await handleGetNarrative(db, fetcher, { nowMs: 1_000 });
+    const secondResponse = await handleGetNarrative(db, fetcher, { nowMs: 1_500 });
+    const secondData = await secondResponse.json();
+
+    expect(firstResponse.status).toBe(502);
+    expect(secondResponse.status).toBe(200);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(secondData.items[0]).toMatchObject({ threadId: "thread-2" });
+  });
+
+  it("uses endpoint-aware cache keys", async () => {
+    const dbOne = await createTestDb();
+    const dbTwo = await createTestDb();
+
+    await seedEmailAgent(dbOne, "http://email-agent-one.test/agent");
+    await seedEmailAgent(dbTwo, "http://email-agent-two.test/agent");
+
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "thread-one",
+              title: "One",
+              snippet: "one",
+              last_activity_at: "2026-02-16T12:01:00.000Z",
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              thread_id: "thread-two",
+              title: "Two",
+              snippet: "two",
+              last_activity_at: "2026-02-16T12:02:00.000Z",
+            },
+          ],
+        })
+      );
+
+    const firstResponse = await handleGetNarrative(dbOne, fetcher, { nowMs: 1_000 });
+    const secondResponse = await handleGetNarrative(dbTwo, fetcher, { nowMs: 1_500 });
+    const firstData = await firstResponse.json();
+    const secondData = await secondResponse.json();
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher).toHaveBeenNthCalledWith(1, "http://email-agent-one.test/narrative", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(fetcher).toHaveBeenNthCalledWith(2, "http://email-agent-two.test/narrative", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(firstData.items[0]).toMatchObject({ threadId: "thread-one" });
+    expect(secondData.items[0]).toMatchObject({ threadId: "thread-two" });
+  });
+
+  it("treats only refresh=1 as cache bypass", () => {
+    expect(shouldBypassNarrativeCache("1")).toBe(true);
+    expect(shouldBypassNarrativeCache(null)).toBe(false);
+    expect(shouldBypassNarrativeCache("0")).toBe(false);
+    expect(shouldBypassNarrativeCache("true")).toBe(false);
+    expect(shouldBypassNarrativeCache("")).toBe(false);
   });
 });

--- a/src/app/api/narrative/__tests__/route.test.ts
+++ b/src/app/api/narrative/__tests__/route.test.ts
@@ -287,6 +287,106 @@ describe("GET /api/narrative", () => {
     expect(data.actionItems).toEqual([]);
   });
 
+  it("returns 500 when an unexpected upstream error is thrown", async () => {
+    const throwingDb = {
+      select: () => {
+        throw new Error("db failure");
+      },
+    } as const;
+
+    const response = await handleGetNarrative(throwingDb as unknown as never, vi.fn());
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data).toMatchObject({ error: "Unable to load email narrative" });
+  });
+
+  it("normalizes nested payload JSON and object action items", async () => {
+    await seedEmailAgent(db);
+
+    const fetcher = vi.fn().mockResolvedValue(
+      jsonResponse({
+        payload: JSON.stringify({
+          items: [
+            {
+              thread_id: "thread-nested",
+              title: "Nested",
+              snippet: "Nested summary",
+              timestamp: 1700000000000,
+            },
+          ],
+          narrative: "Nested payload summary",
+          actionItems: [{ text: "Follow nested thread" }],
+        }),
+      })
+    );
+
+    const response = await handleGetNarrative(db, fetcher);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.items).toHaveLength(1);
+    expect(data.items[0]).toMatchObject({
+      threadId: "thread-nested",
+      title: "Nested",
+      snippet: "Nested summary",
+      lastMessageRole: null,
+    });
+    expect(data.narrative).toBe("Nested payload summary");
+    expect(data.actionItems).toEqual(["Follow nested thread"]);
+  });
+
+  it("sorts stable when timestamps tie on the same millisecond", async () => {
+    await seedEmailAgent(db);
+
+    const fetcher = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          {
+            thread_id: "thread-b",
+            title: "B",
+            snippet: "second",
+            timestamp: 1700000000000,
+          },
+          {
+            thread_id: "thread-a",
+            title: "A",
+            snippet: "first",
+            timestamp: 1700000000000,
+          },
+        ],
+      })
+    );
+
+    const response = await handleGetNarrative(db, fetcher);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.items.map((item: { threadId: string }) => item.threadId)).toEqual([
+      "thread-a",
+      "thread-b",
+    ]);
+  });
+
+  it("ignores SSE chunks without data lines", async () => {
+    await seedEmailAgent(db);
+
+    const body = [
+      ["event: RUN_STARTED", "id: run-empty"].join("\n"),
+      ["event: RUN_FINISHED", "id: run-empty"].join("\n"),
+    ].join("\n\n");
+
+    const fetcher = vi.fn().mockResolvedValue(new Response(body, { status: 200 }));
+
+    const response = await handleGetNarrative(db, fetcher);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.items).toEqual([]);
+    expect(data.narrative).toBe("");
+    expect(data.actionItems).toEqual([]);
+  });
+
   it("reuses cached successful response for repeated requests within TTL", async () => {
     await seedEmailAgent(db);
 

--- a/src/app/api/narrative/route.ts
+++ b/src/app/api/narrative/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db as defaultDb } from "../../../../db/client";
 import { agents } from "../../../../db/schema";
@@ -17,10 +17,53 @@ const EPOCH_ISO = "1970-01-01T00:00:00.000Z";
 
 const SSE_SEPARATOR_REGEX = /\r?\n\r?\n/;
 const SSE_LINE_REGEX = /\r?\n/;
+const NARRATIVE_CACHE_TTL_MS = 60_000;
 
 interface NarrativeSummary {
   narrative: string;
   actionItems: string[];
+}
+
+interface NarrativeCacheEntry {
+  cacheKey: string;
+  payload: LandingNarrativeResponse;
+  cachedAtMs: number;
+  expiresAtMs: number;
+}
+
+interface NarrativeRequestOptions {
+  bypassCache?: boolean;
+  nowMs?: number;
+}
+
+let narrativeCache: NarrativeCacheEntry | null = null;
+
+export function resetNarrativeCacheForTests(): void {
+  narrativeCache = null;
+}
+
+export function shouldBypassNarrativeCache(refreshValue: string | null): boolean {
+  return refreshValue === "1";
+}
+
+function getNarrativeCacheMissReason(
+  cacheEntry: NarrativeCacheEntry | null,
+  cacheKey: string,
+  nowMs: number
+): "empty" | "cache_key_mismatch" | "expired" {
+  if (!cacheEntry) {
+    return "empty";
+  }
+
+  if (cacheEntry.cacheKey !== cacheKey) {
+    return "cache_key_mismatch";
+  }
+
+  if (cacheEntry.expiresAtMs <= nowMs) {
+    return "expired";
+  }
+
+  return "expired";
 }
 
 function toNarrativeEndpoint(endpointUrl: string): string {
@@ -329,9 +372,12 @@ function mapItems(payload: unknown): LandingNarrativeItem[] {
 
 export async function handleGetNarrative(
   db: Db = defaultDb,
-  fetcher: Fetcher = fetch
+  fetcher: Fetcher = fetch,
+  options: NarrativeRequestOptions = {}
 ): Promise<NextResponse> {
   const startedAt = Date.now();
+  const bypassCache = options.bypassCache === true;
+  const nowMs = options.nowMs ?? Date.now();
   const log = logger.child({
     requestId: crypto.randomUUID(),
     route: "/api/narrative",
@@ -362,6 +408,65 @@ export async function handleGetNarrative(
     }
 
     const endpoint = toNarrativeEndpoint(configuredAgent.endpointUrl);
+    const cacheKey = endpoint;
+    const cacheEntry = narrativeCache;
+
+    if (bypassCache) {
+      log.info(
+        {
+          event: "narrative.cache_bypass",
+          cacheKey,
+          bypass: true,
+          source: "upstream",
+          durationMs: Date.now() - startedAt,
+        },
+        "narrative cache bypassed"
+      );
+    } else if (cacheEntry && cacheEntry.cacheKey === cacheKey && cacheEntry.expiresAtMs > nowMs) {
+      const cacheAgeMs = nowMs - cacheEntry.cachedAtMs;
+
+      log.info(
+        {
+          event: "narrative.cache_hit",
+          cacheKey,
+          cacheAgeMs,
+          bypass: false,
+          source: "cache",
+          durationMs: Date.now() - startedAt,
+        },
+        "narrative cache hit"
+      );
+
+      log.info(
+        {
+          event: "narrative.completed",
+          source: "cache",
+          durationMs: Date.now() - startedAt,
+          itemCount: cacheEntry.payload.items.length,
+          actionItemCount: cacheEntry.payload.actionItems.length,
+          narrativeLength: cacheEntry.payload.narrative.length,
+        },
+        "narrative request completed"
+      );
+
+      return NextResponse.json(cacheEntry.payload);
+    } else {
+      const cacheAgeMs =
+        cacheEntry && cacheEntry.cacheKey === cacheKey ? nowMs - cacheEntry.cachedAtMs : undefined;
+
+      log.info(
+        {
+          event: "narrative.cache_miss",
+          cacheKey,
+          cacheAgeMs,
+          bypass: false,
+          source: "upstream",
+          reason: getNarrativeCacheMissReason(cacheEntry, cacheKey, nowMs),
+          durationMs: Date.now() - startedAt,
+        },
+        "narrative cache miss"
+      );
+    }
 
     const response = await fetcher(endpoint, {
       method: "POST",
@@ -394,9 +499,18 @@ export async function handleGetNarrative(
       actionItems: extractedPayload.actionItems,
     };
 
+    const cachedAtMs = options.nowMs ?? Date.now();
+    narrativeCache = {
+      cacheKey,
+      payload: responseBody,
+      cachedAtMs,
+      expiresAtMs: cachedAtMs + NARRATIVE_CACHE_TTL_MS,
+    };
+
     log.info(
       {
         event: "narrative.completed",
+        source: "upstream",
         durationMs: Date.now() - startedAt,
         itemCount: items.length,
         actionItemCount: responseBody.actionItems.length,
@@ -420,7 +534,10 @@ export async function handleGetNarrative(
   }
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const refreshValue = req.nextUrl.searchParams.get("refresh");
+  const bypassCache = shouldBypassNarrativeCache(refreshValue);
+
   await syncAgentsToDb(defaultDb);
-  return handleGetNarrative(defaultDb, fetch);
+  return handleGetNarrative(defaultDb, fetch, { bypassCache });
 }

--- a/src/app/api/narrative/route.ts
+++ b/src/app/api/narrative/route.ts
@@ -50,7 +50,7 @@ function getNarrativeCacheMissReason(
   cacheEntry: NarrativeCacheEntry | null,
   cacheKey: string,
   nowMs: number
-): "empty" | "cache_key_mismatch" | "expired" {
+): "empty" | "cache_key_mismatch" | "expired" | "unexpected_valid_entry" {
   if (!cacheEntry) {
     return "empty";
   }
@@ -63,8 +63,7 @@ function getNarrativeCacheMissReason(
     return "expired";
   }
 
-  return "expired"; // unreachable: caller guarantees miss condition
-
+  return "unexpected_valid_entry";
 }
 
 function toNarrativeEndpoint(endpointUrl: string): string {

--- a/src/app/api/narrative/route.ts
+++ b/src/app/api/narrative/route.ts
@@ -63,7 +63,8 @@ function getNarrativeCacheMissReason(
     return "expired";
   }
 
-  return "expired";
+  return "expired"; // unreachable: caller guarantees miss condition
+
 }
 
 function toNarrativeEndpoint(endpointUrl: string): string {

--- a/src/lib/hooks/__tests__/useNarrative.test.ts
+++ b/src/lib/hooks/__tests__/useNarrative.test.ts
@@ -133,7 +133,8 @@ describe("useNarrative", () => {
   });
 
   it("keeps previous rows and sets refresh overlay error after refresh failure", async () => {
-    vi.spyOn(globalThis, "fetch")
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
         buildOkResponse(
           buildNarrativeResponse({
@@ -162,6 +163,16 @@ describe("useNarrative", () => {
     expect(result.current.narratives.map((item) => item.threadId)).toEqual(["thread-1"]);
     expect(result.current.error).toBeNull();
     expect(result.current.refreshError).toBe("Unable to load email narrative");
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      "/api/narrative",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      "/api/narrative?refresh=1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
   });
 
   it("transitions to terminal_error on 404 during refresh even with prior data", async () => {

--- a/src/lib/hooks/useNarrative.ts
+++ b/src/lib/hooks/useNarrative.ts
@@ -98,7 +98,8 @@ export function useNarrative(): UseNarrativeReturn {
       }
 
       try {
-        const response = await fetch("/api/narrative", { signal: controller.signal });
+        const requestUrl = mode === "refresh" ? "/api/narrative?refresh=1" : "/api/narrative";
+        const response = await fetch(requestUrl, { signal: controller.signal });
 
         if (!mountedRef.current || requestIdRef.current !== requestId) {
           return;


### PR DESCRIPTION
## Summary
- Implements issue #13 by adding a 60s in-memory cache to `GET /api/narrative` with endpoint-aware keying, strict `refresh=1` bypass, and cache observability logs (`hit` / `miss` / `bypass`)
- Keeps existing error mapping and response shape unchanged while ensuring failed upstream responses do not overwrite cached success
- Updates `useNarrative` refresh calls to send `/api/narrative?refresh=1` and extends route/hook tests for cache behavior and refresh bypass wiring
- Marks the implementation plan complete in `docs/plans/2026-02-18-feat-cache-narrative-results-ui-proxy-plan.md`

## Testing
- `bun run test src/app/api/narrative/__tests__/route.test.ts`
- `bun run test src/lib/hooks/__tests__/useNarrative.test.ts`
- `bun run typecheck`
- `bun run lint` *(fails in this workspace because unrelated generated files under `.worktrees/**/.next/**` are linted)*
- `bunx eslint src/app/api/narrative/route.ts src/app/api/narrative/__tests__/route.test.ts src/lib/hooks/useNarrative.ts src/lib/hooks/__tests__/useNarrative.test.ts`

## Post-Deploy Monitoring & Validation
- What to monitor
  - Logs:
    - `event:narrative.cache_hit`
    - `event:narrative.cache_miss`
    - `event:narrative.cache_bypass`
    - `event:narrative.upstream_failed`
    - `event:narrative.failed`
  - Metrics/Dashboards:
    - Cache hit ratio from logs (`cache_hit` vs `cache_miss`) for landing narrative requests
- Validation checks:
  - Load landing page twice within 60s; confirm second request logs `narrative.cache_hit`
  - Trigger manual refresh from landing; confirm request uses `refresh=1` and logs `narrative.cache_bypass`
  - Verify expired-cache path refetches upstream and still returns mapped errors on upstream failure
- Expected healthy behavior
  - Repeated non-refresh loads within 60s mostly produce `cache_hit`
  - Manual refresh always produces `cache_bypass` and refreshes cache on success
  - Error mapping remains `404` source unavailable and generic load failure for other failures
- Failure signal(s) / rollback trigger
  - Sustained spike in `narrative.upstream_failed` or `narrative.failed`, or no observed `cache_hit` events under repeated load
  - Rollback trigger: user-facing narrative load regressions or stale/incorrect payload behavior after refresh
- Validation window and owner
  - First 24 hours post-deploy, owned by the narrative/landing feature on-call engineer

Closes #13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/backland-labs/agent-ui/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
